### PR TITLE
feat: add aarch64 boot code

### DIFF
--- a/arch/aarch64/src/boot.s
+++ b/arch/aarch64/src/boot.s
@@ -1,0 +1,24 @@
+.section .bss
+.align 16
+stack_bottom:
+.skip 16384
+stack_top:
+
+// To keep this in the first portion of the binary.
+.section .text.boot
+.globl _start
+.type _start, @function
+
+// Entry point for the kernel. Registers:
+// x0 -> 32 bit pointer to DTB in memory (primary core only) / 0 (secondary cores)
+// x1 -> 0
+// x2 -> 0
+// x3 -> 0
+// x4 -> 32 bit kernel entry point, _start location
+_start:
+    ldr     x5, =stack_top
+    mov     sp, x5
+    bl      kernel_main
+halt:
+    wfe
+    b halt

--- a/arch/aarch64/src/linker.ld
+++ b/arch/aarch64/src/linker.ld
@@ -1,0 +1,35 @@
+ENTRY(_start)
+
+SECTIONS
+{
+    /* For AArch32, use . = 0x8000; */
+    . = 0x80000;
+    .text :
+    {
+        KEEP(*(.text.boot))
+        *(.text)
+    }
+    . = ALIGN(4096); /* align to page size */
+
+	/* Read-only data. */
+    .rodata :
+    {
+        *(.rodata)
+    }
+    . = ALIGN(4096); /* align to page size */
+
+	/* Read-write data (initialized) */
+    .data :
+    {
+        *(.data)
+    }
+    . = ALIGN(4096); /* align to page size */
+
+	/* Read-write data (uninitialized) and stack */
+    .bss :
+    {
+        *(COMMON)
+        *(.bss)
+    }
+}
+

--- a/build.zig
+++ b/build.zig
@@ -3,9 +3,15 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     // Build is restricted to x86 (32bit) for simplicity for now; longer goals include
     // expanding this to aarch64 + x86_64.
-    const target = b.resolveTargetQuery(.{ .os_tag = .freestanding, .cpu_arch = .x86 });
+    const x86: std.Target.Query = .{ .os_tag = .freestanding, .cpu_arch = .x86 };
+    const aarch64: std.Target.Query = .{ .os_tag = .freestanding, .cpu_arch = .aarch64 };
+    const target = b.standardTargetOptions(.{ .whitelist = &[_]std.Target.Query{ aarch64, x86 }, .default_target = x86 });
     // Assume aarch64 if not x86 for now, consider adding more in-depth parsing later.
-    const archPath = if (target.result.cpu.arch == .x86) "x86" else "aarch64";
+    const archPath = switch (target.result.cpu.arch) {
+        .x86 => "x86",
+        .aarch64 => "aarch64",
+        else => @panic("Unhandled target\n"),
+    };
 
     // Standard optimization options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not


### PR DESCRIPTION
This adds minimal boot code for aarch64, compatible with a raspberry pi 4.