### PR TITLE
feat: add arch interface and serial

### DIFF
--- a/src/arch.zig
+++ b/src/arch.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const Serial = @import("serial.zig").Serial;
+
+pub const Arch = struct {
+    initSerial: fn (self: @This()) struct { success: bool, serial: ?Serial } = initSerialBase,
+};
+
+pub fn initSerialBase(self: *Arch) struct { success: bool, serial: ?Serial } {
+    _ = self;
+    return .{ false, null };
+}
+
+pub fn get(cpu: std.Target.Cpu) Arch {
+    return switch (cpu.arch) {
+        else => .{},
+    };
+}

--- a/src/arch.zig
+++ b/src/arch.zig
@@ -2,12 +2,13 @@ const std = @import("std");
 const Serial = @import("serial.zig").Serial;
 
 pub const Arch = struct {
-    initSerial: fn (self: @This()) struct { success: bool, serial: ?Serial } = initSerialBase,
+    const SerialResult = struct { success: bool, serial: ?Serial };
+    initSerial: fn (self: *const @This()) SerialResult = initSerialBase,
 };
 
-pub fn initSerialBase(self: *Arch) struct { success: bool, serial: ?Serial } {
+pub fn initSerialBase(self: *const Arch) Arch.SerialResult {
     _ = self;
-    return .{ false, null };
+    return .{ .success = false, .serial = null };
 }
 
 pub fn get(cpu: std.Target.Cpu) Arch {

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -9,6 +9,7 @@ pub fn log(comptime level: std.log.level, comptime scope: @TypeOf(.EnumLiteral),
 
 export fn kernel_main() void {
     const arch_ifc = arch.get(builtin.cpu);
-    serial.init(arch_ifc);
+    if (!serial.init(&arch_ifc))
+        return;
     return;
 }

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -1,3 +1,14 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const serial = @import("serial.zig");
+const arch = @import("arch.zig");
+
+pub fn log(comptime level: std.log.level, comptime scope: @TypeOf(.EnumLiteral), comptime format: []const u8, args: anytype) void {
+    serial.log(level, "(" ++ @tagName(scope) ++ "): " ++ format, args);
+}
+
 export fn kernel_main() void {
+    const arch_ifc = arch.get(builtin.cpu);
+    serial.init(arch_ifc);
     return;
 }

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const Arch = @import("arch.zig").Arch;
+
+pub const Serial = struct {
+    const This = @This();
+    /// A function that takes a byte and writes it to the serial stream
+    pub const Write = fn (byte: u8) bool;
+
+    /// The interface's writer
+    writer: Write,
+
+    pub fn writeBytes(self: *const This, bytes: []const u8) usize {
+        var i: usize = 0;
+        for (bytes) |byte| {
+            if (self.writer(byte)) {
+                i += 1;
+            } else break;
+        }
+        return i;
+    }
+};
+
+const LoggingError = error{};
+/// Create a Writer that uses logCallback to write some bytes to serial
+const Writer = std.io.Writer(void, LoggingError, logCallback);
+
+/// The architecture's serial interface, null if not initialised yet
+var serial: ?Serial = null;
+
+/// Write a format string to the serial interface
+fn log(comptime level: std.log.level, comptime format: []const u8, args: anytype) void {
+    std.fmt.format(Writer{ .context = {} }, "[" ++ @tagName(level) ++ "] " ++ format, args) catch unreachable;
+}
+
+/// The standard library formatter will call this function with the bytes to print
+fn logCallback(context: void, str: []const u8) usize {
+    _ = context;
+    if (serial) |serial_ifc| {
+        return serial_ifc.writeBytes(str);
+    }
+    return 0;
+}
+
+pub fn init(arch: *const Arch) bool {
+    const result = arch.initSerial(&serial);
+    if (result.success)
+        serial = result.serial orelse unreachable;
+    return result.success;
+}

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -4,7 +4,7 @@ const Arch = @import("arch.zig").Arch;
 pub const Serial = struct {
     const This = @This();
     /// A function that takes a byte and writes it to the serial stream
-    pub const Write = fn (byte: u8) bool;
+    pub const Write = *const fn (u8) bool;
 
     /// The interface's writer
     writer: Write,
@@ -25,7 +25,7 @@ const LoggingError = error{};
 const Writer = std.io.Writer(void, LoggingError, logCallback);
 
 /// The architecture's serial interface, null if not initialised yet
-var serial: ?Serial = null;
+pub var serial: ?Serial = null;
 
 /// Write a format string to the serial interface
 fn log(comptime level: std.log.level, comptime format: []const u8, args: anytype) void {
@@ -42,7 +42,7 @@ fn logCallback(context: void, str: []const u8) usize {
 }
 
 pub fn init(arch: *const Arch) bool {
-    const result = arch.initSerial(&serial);
+    const result = arch.initSerial(arch);
     if (result.success)
         serial = result.serial orelse unreachable;
     return result.success;


### PR DESCRIPTION
This is a start of an architecture interface so that the main kernel functions can be as architecture-agnostic as possible. I'd still like to separate out the serial changes from this PR to make it more atomic, but it gives an idea of how it would be used.